### PR TITLE
Update SitRadaJanv2017.R

### DIFF
--- a/Heatmap/SitRadaJanv2017.R
+++ b/Heatmap/SitRadaJanv2017.R
@@ -50,7 +50,7 @@ heatmap.2(CompM, Rowv = FALSE,
 
 ### Dendrogramme sur distance khi-deux
 tCompM <- t(CompM)  # tableau transposé
-thc <- hclust(as.dist(distChi2(tCompM)), method = "ward.D")  # ici il n'y a pas de réinjection des poids des lignes & colonnes
+thc <- hclust(as.dist(distChi2(tCompM)), method = "ward.D2")  # ici il n'y a pas de réinjection des poids des lignes & colonnes
 plot(thc, hang = -1, cex = 0.6)
 
 ## Test de la proposition de R. Cura : http://rpubs.com/RobinC/AFC_CAH


### PR DESCRIPTION
Changement en methode "ward.D2" car
"Two different algorithms are found in the literature for Ward clustering. The one used by option "ward.D" (equivalent to the only Ward option "ward" in R versions <= 3.0.3) does not implement Ward's (1963) clustering criterion, whereas option "ward.D2" implements that criterion (Murtagh and Legendre 2014). With the latter, the dissimilarities are squared before cluster updating. Note that agnes(*, method="ward") corresponds to hclust(*, "ward.D2")." selon le package hclust